### PR TITLE
Shadow Monarch scaling, EP gain adjustments, and stat system overhaul

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,3 +117,12 @@ runs/
 
 # Avoid ignoring Gradle wrapper jar file (.jar files are usually ignored)
 !gradle-wrapper.jar
+
+# Project-specific ignores
+lib/
+github version/
+last version/
+update/
+cfr.jar
+error.txt
+trawakened-*.jar

--- a/src/main/java/io/github/dracosomething/trawakened/ability/skill/unique/SystemSkill.java
+++ b/src/main/java/io/github/dracosomething/trawakened/ability/skill/unique/SystemSkill.java
@@ -77,14 +77,13 @@ public class SystemSkill extends Skill implements ISpatialStorage {
         return 140;
     }
 
-    // Método para determinar multiplicador de bônus baseado no Shadow Monarch
     private double getBonusMultiplier(LivingEntity user, boolean mastered) {
-        if (!mastered) return 1.0; // Sem maestria = sem bônus
+        if (!mastered) return 1.0;
         
         boolean hasShadowMonarch = SkillAPI.getSkillsFrom(user).getSkill(skillRegistry.SHADOW_MONARCH.get()).isPresent();
         
         if (!hasShadowMonarch) {
-            return 1.2; // System com maestria apenas: +20%
+            return 1.2;
         }
         
         ManasSkillInstance shadowInstance = SkillAPI.getSkillsFrom(user).getSkill(skillRegistry.SHADOW_MONARCH.get()).get();
@@ -96,45 +95,39 @@ public class SystemSkill extends Skill implements ISpatialStorage {
         }
         
         if (isShadowMonarchAwakened) {
-            return 3.0; // Shadow Monarch awakened: +200%
+            return 3.0;
         } else if (hasShadowMonarchMastery) {
-            return 2.0; // Shadow Monarch com maestria: +100%
+            return 2.0;
         } else {
-            return 1.5; // Shadow Monarch básico: +50%
+            return 1.5;
         }
     }
 
     private double getSystemSpeedBonus(int level, boolean mastered, LivingEntity user) {
-        // Fórmula para atingir +0.15 no level 140 (progressão linear)
-        double baseBonus = level * 0.00107143; // 140 * 0.00107143 ≈ 0.15
+        double baseBonus = level * 0.00107143;
         double multiplier = getBonusMultiplier(user, mastered);
         double finalBonus = baseBonus * multiplier;
-        // Cap de velocidade de +0.15
         return Math.min(finalBonus, 0.15);
     }
 
     private double getSystemAttackBonus(int level, boolean mastered, LivingEntity user) {
-        // Fórmula para atingir +70.0 no level 140
-        double baseBonus = level * 0.5; // 140 * 0.5 = 70.0
+        double baseBonus = level * 0.5;
         double multiplier = getBonusMultiplier(user, mastered);
         return baseBonus * multiplier;
     }
 
     private double getSystemArmorBonus(int level, boolean mastered, LivingEntity user) {
-        // Fórmula para atingir ~58.3 no level 140 (baseado em levels 30+)
         if (level < 30) return 0.0;
-        double baseBonus = ((level - 30) / 30.0 + 1) * 12.5; // A cada 30 levels: +12.5 armor
+        double baseBonus = ((level - 30) / 30.0 + 1) * 12.5;
         double multiplier = getBonusMultiplier(user, mastered);
         return baseBonus * multiplier;
     }
 
     private void applySystemModifiers(LivingEntity entity, int level, boolean mastered) {
-        // Remove modificadores anteriores
         AttributeInstance speedAttr = entity.getAttribute(Attributes.MOVEMENT_SPEED);
         AttributeInstance damageAttr = entity.getAttribute(Attributes.ATTACK_DAMAGE);
         AttributeInstance armorAttr = entity.getAttribute(Attributes.ARMOR);
         
-        // Aplica modificador de velocidade
         if (speedAttr != null) {
             speedAttr.removeModifier(SYSTEM_SPEED_UUID);
             double speedBonus = getSystemSpeedBonus(level, mastered, entity);
@@ -149,7 +142,6 @@ public class SystemSkill extends Skill implements ISpatialStorage {
             }
         }
         
-        // Aplica modificador de dano
         if (damageAttr != null) {
             damageAttr.removeModifier(SYSTEM_DAMAGE_UUID);
             double damageBonus = getSystemAttackBonus(level, mastered, entity);

--- a/src/main/java/io/github/dracosomething/trawakened/ability/skill/unique/SystemSkill.java
+++ b/src/main/java/io/github/dracosomething/trawakened/ability/skill/unique/SystemSkill.java
@@ -104,10 +104,10 @@ public class SystemSkill extends Skill implements ISpatialStorage {
     }
 
     private double getSystemSpeedBonus(int level, boolean mastered, LivingEntity user) {
-        double baseBonus = level * 0.00107143;
+        double baseBonus = level * 0.000285714; // Reduced multiplier for 0.04 cap
         double multiplier = getBonusMultiplier(user, mastered);
         double finalBonus = baseBonus * multiplier;
-        return Math.min(finalBonus, 0.15);
+        return Math.min(finalBonus, 0.04); // Reduced speed cap
     }
 
     private double getSystemAttackBonus(int level, boolean mastered, LivingEntity user) {
@@ -156,7 +156,7 @@ public class SystemSkill extends Skill implements ISpatialStorage {
             }
         }
         
-        // Aplica modificador de armadura (seguindo padrão Tensura)
+        // Apply armor modifier (following Tensura pattern)
         if (armorAttr != null) {
             armorAttr.removeModifier(SYSTEM_ARMOR_UUID);
             double armorBonus = getSystemArmorBonus(level, mastered, entity);
@@ -199,7 +199,6 @@ public class SystemSkill extends Skill implements ISpatialStorage {
             SpatialStorageContainer container = this.getSpatialStorage(instance);
             tag.putBoolean("isGui", true);
             instance.getOrCreateTag().put("data", this.tag);
-            System.out.println(instance.getTag());
             TensuraNetwork.INSTANCE.send(PacketDistributor.PLAYER.with(() -> {
                 return player;
             }), new ClientboundSpatialStorageOpenPacket(player.getId(), player.containerCounter, container.getContainerSize(), container.getMaxStackSize(), SkillUtils.getSkillId(skill)));
@@ -225,7 +224,7 @@ public class SystemSkill extends Skill implements ISpatialStorage {
         int level = instance.getOrCreateTag().getInt("level");
         boolean mastered = instance.isMastered(entity);
         
-        // Aplica modificadores de velocidade, dano e armadura usando AttributeModifiers
+        // Apply speed, damage and armor modifiers using AttributeModifiers
         applySystemModifiers(entity, level, mastered);
         
         instance.addMasteryPoint(entity);
@@ -239,7 +238,7 @@ public class SystemSkill extends Skill implements ISpatialStorage {
         int level = instance.getOrCreateTag().getInt("level");
         boolean mastered = instance.isMastered(living);
         
-        // Aplica modificadores de velocidade, dano e armadura usando AttributeModifiers
+        // Apply speed, damage and armor modifiers using AttributeModifiers
         applySystemModifiers(living, level, mastered);
     }
 

--- a/src/main/java/io/github/dracosomething/trawakened/handler/SystemHandler.java
+++ b/src/main/java/io/github/dracosomething/trawakened/handler/SystemHandler.java
@@ -65,7 +65,6 @@ public class SystemHandler {
         }
     }
 
-    // Métodos auxiliares para System skill
     private static int getMaxLevel(LivingEntity user) {
         boolean hasSystemMastery = SkillAPI.getSkillsFrom(user).getSkill(skillRegistry.SYSTEM.get()).isPresent() &&
                 SkillAPI.getSkillsFrom(user).getSkill(skillRegistry.SYSTEM.get()).get().getMastery() >= 1.0;
@@ -82,7 +81,6 @@ public class SystemHandler {
             }
         }
 
-        // Determinar max level baseado nas condições
         if (isShadowMonarchAwakened) {
             return 500;
         } else if (hasShadowMonarchMastery) {
@@ -112,11 +110,9 @@ public class SystemHandler {
                     tag.putInt("level", 1);
                 }
                 
-                // Atualizar maxLevel dinamicamente baseado nas skills
                 int maxLevel = getMaxLevel(user);
                 tag.putInt("maxLevel", maxLevel);
                 
-                // EP ganhado sem multiplicador adicional (já aplicado via SkillUtilsMixin)
                 int epGained = (int) (event.getNewEP() - event.getOldEP());
                 int accumulatedEP = tag.getInt("accumulatedEP") + epGained;
                 tag.putInt("accumulatedEP", accumulatedEP);

--- a/src/main/java/io/github/dracosomething/trawakened/menu/ShadowSummonScreen.java
+++ b/src/main/java/io/github/dracosomething/trawakened/menu/ShadowSummonScreen.java
@@ -46,7 +46,7 @@ public class ShadowSummonScreen extends Screen {
         CompoundTag storage = skill.getShadowStorage();
         
         for (String key : storage.getAllKeys()) {
-            System.out.println(key);
+            // Debug log removed for production
             CompoundTag shadowData = storage.getCompound(key);
             String entityType = shadowData.getString("entityType");
             String name = shadowData.getString("name");
@@ -73,7 +73,7 @@ public class ShadowSummonScreen extends Screen {
         super.init();
         
         this.columns = Math.max(1, Math.min(4, this.width / 220));
-        this.maxVisiblePerColumn = Math.max(5, Math.min(12, (this.height - 220) / 22)); // Reduzida a quantidade máxima e aumentado o espaço reservado
+        this.maxVisiblePerColumn = Math.max(5, Math.min(12, (this.height - 220) / 22)); // Reduced maximum quantity and increased reserved space
         this.maxVisibleTotal = maxVisiblePerColumn * columns;
 
         int centerX = this.width / 2;
@@ -156,17 +156,17 @@ public class ShadowSummonScreen extends Screen {
             index++;
         }
         
-        // Definir variáveis para botões principais primeiro
+        // Define main button variables first
         int mainButtonWidth = Math.max(80, buttonWidth / 2);
         int mainButtonHeight = Math.max(18, buttonHeight + 2);
-        int bottomMargin = Math.max(35, this.height / 15); // Aumentada ainda mais a margem inferior
+        int bottomMargin = Math.max(35, this.height / 15); // Further increased bottom margin
         int buttonSpacing = Math.max(5, mainButtonHeight / 3);
         int mainButtonY = this.height - bottomMargin - (mainButtonHeight * 2) - buttonSpacing;
         
         int navButtonWidth = Math.max(40, buttonWidth / 4);
         int navButtonHeight = Math.max(16, buttonHeight);
         
-        int navSpacing = Math.max(20, this.height / 25); // Aumentado ainda mais o espaçamento
+        int navSpacing = Math.max(20, this.height / 25); // Further increased spacing
         int navY = mainButtonY - navButtonHeight - navSpacing;
         
         if (scrollOffset > 0) {
@@ -202,7 +202,7 @@ public class ShadowSummonScreen extends Screen {
         
         this.addRenderableWidget(new Button(
             centerX - (mainButtonWidth * 2/3) / 2, mainButtonY + mainButtonHeight + buttonSpacing, 
-            mainButtonWidth * 2/3, mainButtonHeight, // Usar a mesma altura do botão principal
+            mainButtonWidth * 2/3, mainButtonHeight, // Use the same height as main button
             Component.translatable("gui.cancel"),
             button -> this.onClose()
         ));

--- a/src/main/java/io/github/dracosomething/trawakened/mixin/SkillUtilsMixin.java
+++ b/src/main/java/io/github/dracosomething/trawakened/mixin/SkillUtilsMixin.java
@@ -1,16 +1,55 @@
 package io.github.dracosomething.trawakened.mixin;
 
-import com.github.manasmods.manascore.api.skills.SkillAPI;
-import com.github.manasmods.tensura.ability.SkillUtils;
-import io.github.dracosomething.trawakened.registry.skillRegistry;
-import net.minecraft.world.entity.player.Player;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
+import com.github.manasmods.manascore.api.skills.ManasSkillInstance;
+import com.github.manasmods.manascore.api.skills.SkillAPI;
+import com.github.manasmods.tensura.ability.SkillUtils;
+
+import io.github.dracosomething.trawakened.ability.skill.ultimate.ShadowMonarch;
+import io.github.dracosomething.trawakened.registry.skillRegistry;
+import net.minecraft.world.entity.player.Player;
+
 @Mixin(value = SkillUtils.class, remap = false)
 public class SkillUtilsMixin {
+    
+    // Método auxiliar para calcular multiplicador dinâmico
+    private static float getSystemMultiplier(Player player) {
+        if (!SkillAPI.getSkillsFrom(player).getSkill(skillRegistry.SYSTEM.get()).isPresent()) {
+            return 1.0f; // Sem System = sem multiplicador
+        }
+        
+        // Verificar se tem Shadow Monarch
+        boolean hasShadowMonarch = SkillAPI.getSkillsFrom(player).getSkill(skillRegistry.SHADOW_MONARCH.get()).isPresent();
+        
+        if (!hasShadowMonarch) {
+            // Sem Shadow Monarch: verificar maestria do System
+            ManasSkillInstance systemInstance = SkillAPI.getSkillsFrom(player).getSkill(skillRegistry.SYSTEM.get()).get();
+            boolean hasSystemMastery = systemInstance.getMastery() >= 1.0;
+            return hasSystemMastery ? 3.5f : 2.5f;
+        }
+        
+        // Com Shadow Monarch: verificar maestria e awakened
+        ManasSkillInstance shadowInstance = SkillAPI.getSkillsFrom(player).getSkill(skillRegistry.SHADOW_MONARCH.get()).get();
+        boolean hasShadowMonarchMastery = shadowInstance.getMastery() >= 1.0;
+        
+        boolean isShadowMonarchAwakened = false;
+        if (shadowInstance.getSkill() instanceof ShadowMonarch skill) {
+            isShadowMonarchAwakened = skill.getData().getBoolean("awakened");
+        }
+
+        // Determinar multiplicador baseado no Shadow Monarch
+        if (isShadowMonarchAwakened) {
+            return 7.0f; // Shadow Monarch awakened
+        } else if (hasShadowMonarchMastery) {
+            return 5.5f; // Shadow Monarch com maestria
+        } else {
+            return 4.5f; // Shadow Monarch básico
+        }
+    }
     
     @Inject(
         method = "getMagiculeGain",
@@ -19,9 +58,15 @@ public class SkillUtilsMixin {
         remap = false
     )
     private static void applySystemSkillMagiculeMultiplier(Player player, boolean majin, CallbackInfoReturnable<Float> cir) {
-        if (SkillAPI.getSkillsFrom(player).getSkill(skillRegistry.SYSTEM.get()).isPresent()) {
+        float multiplier = getSystemMultiplier(player);
+        if (multiplier > 1.0f) {
             float currentValue = cir.getReturnValue();
-            cir.setReturnValue(currentValue * 2.5f);
+            float newValue = currentValue * multiplier;
+            
+            // Debug log para verificar se está funcionando
+            System.out.println("[System Skill] Magicule Multiplier aplicado: " + currentValue + " -> " + newValue + " (x" + multiplier + ")");
+            
+            cir.setReturnValue(newValue);
         }
     }
 
@@ -32,9 +77,15 @@ public class SkillUtilsMixin {
         remap = false
     )
     private static void applySystemSkillAuraMultiplier(Player player, boolean majin, CallbackInfoReturnable<Float> cir) {
-        if (SkillAPI.getSkillsFrom(player).getSkill(skillRegistry.SYSTEM.get()).isPresent()) {
+        float multiplier = getSystemMultiplier(player);
+        if (multiplier > 1.0f) {
             float currentValue = cir.getReturnValue();
-            cir.setReturnValue(currentValue * 2.5f);
+            float newValue = currentValue * multiplier;
+            
+            // Debug log para verificar se está funcionando
+            System.out.println("[System Skill] Aura Multiplier aplicado: " + currentValue + " -> " + newValue + " (x" + multiplier + ")");
+            
+            cir.setReturnValue(newValue);
         }
     }
 }

--- a/src/main/java/io/github/dracosomething/trawakened/mixin/SkillUtilsMixin.java
+++ b/src/main/java/io/github/dracosomething/trawakened/mixin/SkillUtilsMixin.java
@@ -16,23 +16,19 @@ import net.minecraft.world.entity.player.Player;
 @Mixin(value = SkillUtils.class, remap = false)
 public class SkillUtilsMixin {
     
-    // Método auxiliar para calcular multiplicador dinâmico
     private static float getSystemMultiplier(Player player) {
         if (!SkillAPI.getSkillsFrom(player).getSkill(skillRegistry.SYSTEM.get()).isPresent()) {
-            return 1.0f; // Sem System = sem multiplicador
+            return 1.0f;
         }
         
-        // Verificar se tem Shadow Monarch
         boolean hasShadowMonarch = SkillAPI.getSkillsFrom(player).getSkill(skillRegistry.SHADOW_MONARCH.get()).isPresent();
         
         if (!hasShadowMonarch) {
-            // Sem Shadow Monarch: verificar maestria do System
             ManasSkillInstance systemInstance = SkillAPI.getSkillsFrom(player).getSkill(skillRegistry.SYSTEM.get()).get();
             boolean hasSystemMastery = systemInstance.getMastery() >= 1.0;
             return hasSystemMastery ? 3.5f : 2.5f;
         }
         
-        // Com Shadow Monarch: verificar maestria e awakened
         ManasSkillInstance shadowInstance = SkillAPI.getSkillsFrom(player).getSkill(skillRegistry.SHADOW_MONARCH.get()).get();
         boolean hasShadowMonarchMastery = shadowInstance.getMastery() >= 1.0;
         
@@ -41,13 +37,12 @@ public class SkillUtilsMixin {
             isShadowMonarchAwakened = skill.getData().getBoolean("awakened");
         }
 
-        // Determinar multiplicador baseado no Shadow Monarch
         if (isShadowMonarchAwakened) {
-            return 7.0f; // Shadow Monarch awakened
+            return 7.0f;
         } else if (hasShadowMonarchMastery) {
-            return 5.5f; // Shadow Monarch com maestria
+            return 5.5f;
         } else {
-            return 4.5f; // Shadow Monarch básico
+            return 4.5f;
         }
     }
     
@@ -63,7 +58,6 @@ public class SkillUtilsMixin {
             float currentValue = cir.getReturnValue();
             float newValue = currentValue * multiplier;
             
-            // Debug log para verificar se está funcionando
             System.out.println("[System Skill] Magicule Multiplier aplicado: " + currentValue + " -> " + newValue + " (x" + multiplier + ")");
             
             cir.setReturnValue(newValue);
@@ -82,7 +76,6 @@ public class SkillUtilsMixin {
             float currentValue = cir.getReturnValue();
             float newValue = currentValue * multiplier;
             
-            // Debug log para verificar se está funcionando
             System.out.println("[System Skill] Aura Multiplier aplicado: " + currentValue + " -> " + newValue + " (x" + multiplier + ")");
             
             cir.setReturnValue(newValue);

--- a/src/main/java/io/github/dracosomething/trawakened/mixin/SkillUtilsMixin.java
+++ b/src/main/java/io/github/dracosomething/trawakened/mixin/SkillUtilsMixin.java
@@ -58,7 +58,7 @@ public class SkillUtilsMixin {
             float currentValue = cir.getReturnValue();
             float newValue = currentValue * multiplier;
             
-            System.out.println("[System Skill] Magicule Multiplier aplicado: " + currentValue + " -> " + newValue + " (x" + multiplier + ")");
+
             
             cir.setReturnValue(newValue);
         }
@@ -76,7 +76,7 @@ public class SkillUtilsMixin {
             float currentValue = cir.getReturnValue();
             float newValue = currentValue * multiplier;
             
-            System.out.println("[System Skill] Aura Multiplier aplicado: " + currentValue + " -> " + newValue + " (x" + multiplier + ")");
+
             
             cir.setReturnValue(newValue);
         }


### PR DESCRIPTION
I added some updates to the system. I'm not sure if you'll approve all of them, as some might be too strong despite the difficulty for the player to obtain them:
The system now has a max level that scales with Shadow Monarch.

Normal: 140
With Shadow Monarch: 240
With Mastery: 360
With Awakening: 500

The EP gain multiplier was also increased due to the new level cap (assuming you won’t be able to farm bosses easily). The Tensura system’s EP reduction was making players gain almost less than 10 EP per non-boss mob at 1M EP before.

I also made some adjustments to the shadow summon screen – it should be better now, but not drastically improved.

I reduced the system’s max speed and adjusted it to grant stats in Tensura terms (Attack Damage, Armor, and Sprint Speed) instead of effects. (Though I couldn’t integrate the speed into the scroll speed control.)

I also added a bonus to attributes with system mastery, which increases with Shadow Monarch, because the effects were too powerful yet easily neutralized by any skill that blocked them. Now they’re harder to reduce and have almost the same impact as before, only becoming stronger when the player achieves Shadow Monarch mastery.